### PR TITLE
Update how-to-create-hybridazureadjoin-federated.md

### DIFF
--- a/articles/azure-active-directory/how-to-create-hybridazureadjoin-federated.md
+++ b/articles/azure-active-directory/how-to-create-hybridazureadjoin-federated.md
@@ -279,13 +279,7 @@ AD FS サービスの再起動を要求されるので、「OK」を押して画
 
 ![](./how-to-create-hybridazureadjoin-federated/048.jpg)
 
-再度同じエンドポイントを選択し右クリックより「プロキシに対して有効にする」をクリックします。
-
-![](./how-to-create-hybridazureadjoin-federated/049.jpg)
-
-同じように AD FS サービスの再起動を要求されるので、「OK」を押して画面を閉じます。
-
-![](./how-to-create-hybridazureadjoin-federated/050.jpg)
+※ 上記エンドポイントはイントラネット環境向けにのみ有効化します。プロキシ向けに手動で有効化する必要はありません。
 
 サービス画面より Active Directory フェデレーション サービス (AD FS) を右クリックし、「再起動」をクリックします。
 


### PR DESCRIPTION
windowstransport エンドポイントはイントラネット (AD FS) 向けにのみ有効化する必要があり、プロキシ (WAP) 向けに有効化する必要はない (するべきではない) ため、該当箇所の手順を削除し、文言を一文追加しました。