### PR TITLE
use v1 tag

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -27,7 +27,7 @@ jobs:
         # skip checking if pr is created by repository owner
         if: github.event.pull_request.head.repo.owner.login != github.event.repository.owner.login
         id: check_linked_account
-        uses: cssjpn/blog-gh-actions/check-linked-account@6a4d9070f51258dc1da9dd616fd521bd9587f5dc
+        uses: cssjpn/blog-gh-actions/check-linked-account@v1
         with:
           token: ${{ secrets.JPCSSBLOG_DEV_TOKEN }}
           allowExternalUser: 'allow'

--- a/.github/workflows/update-credential.yml
+++ b/.github/workflows/update-credential.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get JPCSSBlogDev Token
         id: jpcssblogdev
-        uses: cssjpn/blog-gh-actions/jpcssblogdev-token@6a4d9070f51258dc1da9dd616fd521bd9587f5dc
+        uses: cssjpn/blog-gh-actions/jpcssblogdev-token@v1
 
       - name: Generate GitHub token for writing secrets
         id: generate_token


### PR DESCRIPTION
use [v1.0.4](https://github.com/cssjpn/blog-gh-actions/releases/tag/v1.0.4) instead of sha [6a4d9070f51258dc1da9dd616fd521bd9587f5dc](https://github.com/cssjpn/blog-gh-actions/pull/4/commits/6a4d9070f51258dc1da9dd616fd521bd9587f5dc).