### PR TITLE
update add google search console

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ skip_render:
   - '_data/*.png'
   - 'BingSiteAuth.xml'
   - 'google4a4cd09c454aa91c.html'
+  - 'googled8c17265b946fbce.html'
 
 # Deployment
 ## Docs: https://hexo.io/doc  s/deployment.html

--- a/source/googled8c17265b946fbce.html
+++ b/source/googled8c17265b946fbce.html
@@ -1,0 +1,1 @@
+google-site-verification: googled8c17265b946fbce.html


### PR DESCRIPTION
[Google Search Console](https://dev.azure.com/jpcss-blog/public/_wiki/wikis/css-blog-wiki/15/admin-settings?anchor=google-search-console-%E3%81%AE%E8%A8%AD%E5%AE%9A%E6%96%B9%E6%B3%95)の設定を行ってみました。
デプロイ後のアクセス URL は https://github.com/jpazureid/blog/googled8c17265b946fbce.html です
